### PR TITLE
added PHP7.2-7.4

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.2-cli
+ADD http://get.sensiolabs.org/security-checker.phar /usr/local/bin/security-checker
+RUN chmod +x /usr/local/bin/security-checker
+CMD ["/usr/local/bin/security-checker","security:check","/composer.lock"]

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.3-cli
+ADD http://get.sensiolabs.org/security-checker.phar /usr/local/bin/security-checker
+RUN chmod +x /usr/local/bin/security-checker
+CMD ["/usr/local/bin/security-checker","security:check","/composer.lock"]

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.4-cli
+ADD https://get.sensiolabs.org/security-checker.phar /usr/local/bin/security-checker
+RUN chmod +x /usr/local/bin/security-checker
+CMD ["/usr/local/bin/security-checker","security:check","/composer.lock"]

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
     docker run --rm -v $(pwd)/composer.lock:/composer.lock jsixc/sensiolabs-security-checker:7.1
 
-The tag refers to the version of PHP. Currently `5.6`, `7.0`, and `7.1` are available.
+The tag refers to the version of PHP. Currently `7.1`, `7.2`, `7.3`, `7.4` are available.


### PR DESCRIPTION
- Added all supported PHP version
- Drop PHP<7.1, as it's not supported anymore.

Main reason why I build new images: The old images on [Dockerhub](https://hub.docker.com/r/jsixc/sensiolabs-security-checker/) use a old .phar with old hosts -> "An error occurred: Could not resolve host: security.sensiolabs.org." 
-> Would be great to build the images on Dockerhub regularly to keep the checker up to date :) 

